### PR TITLE
Fix post deployment scripts that elasticbeanstalk (EB) runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ nosetests.xml
 # PyCharm
 .idea
 
+# Mac OS X
+.DS_Store
+
 # Environment variables
 .env
 
@@ -45,3 +48,7 @@ staticfiles/
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md

--- a/.platform/confighooks/postdeploy/01_collectstatic.sh
+++ b/.platform/confighooks/postdeploy/01_collectstatic.sh
@@ -1,8 +1,27 @@
 #!/bin/bash
+# Manual collectstatic trigger via env update
+set -euo pipefail
 
-source "$PYTHONPATH/activate" && {
+echo "Manual collectstatic trigger (confighooks/postdeploy)..."
 
-    cd /var/app/current/src/odm2cvs || exit 1;
-    echo "Collecting static files as part of AWS auto redeployment of this application due to configuration changes or auto-scaling:";
-    python manage.py collectstatic --noinput;
-}
+# Resolve virtual environment
+VENV_DIR=$(ls -d /var/app/venv/* | head -n 1)
+VENV_ACTIVATE="$VENV_DIR/bin/activate"
+if ! source "$VENV_ACTIVATE"; then
+    echo "ERROR: Failed to activate virtual environment at $VENV_ACTIVATE"
+    exit 1
+fi
+echo "Virtual environment activated."
+
+# Change to Django project
+PROJECT_DIR="/var/app/current/src/odm2cvs"
+if ! cd "$PROJECT_DIR"; then
+    echo "ERROR: Failed to cd into $PROJECT_DIR"
+    exit 1
+fi
+echo "Changed directory to $PROJECT_DIR"
+
+# Always run on single-instance / leader node
+echo "Collecting static files..."
+python manage.py collectstatic --noinput
+echo "Static files collected successfully."

--- a/.platform/hooks/postdeploy/01_migrate.sh
+++ b/.platform/hooks/postdeploy/01_migrate.sh
@@ -1,18 +1,49 @@
 #!/bin/bash
+# Robust EB migrate script with dynamic virtualenv
+# Works for beta and prod environments
+# Prints detailed error messages
 
-source "$PYTHONPATH/activate" && {
+set -euo pipefail
 
-    if [[ $EB_IS_COMMAND_LEADER == "true" ]];
-    then
-        cd /var/app/current/src/odm2cvs || exit 1;
-        echo "Listing migrations before running migrate command:";
-        python manage.py showmigrations;
-        echo "Running migrate command:";
-        python manage.py migrate --noinput;
-        echo "Listing migrations after running migrate command:";
-        python manage.py showmigrations;
+echo "Starting Django migrate script..."
+
+# Resolve virtual environment dynamically
+VENV_DIR=$(ls -d /var/app/venv/* | head -n 1)
+VENV_ACTIVATE="$VENV_DIR/bin/activate"
+
+if ! source "$VENV_ACTIVATE"; then
+    echo "ERROR: Failed to activate virtual environment at $VENV_ACTIVATE"
+    exit 1
+else
+    echo "Virtual environment activated successfully."
+fi
+
+# Change to Django project directory
+PROJECT_DIR="/var/app/current/src/odm2cvs"
+if ! cd "$PROJECT_DIR"; then
+    echo "ERROR: Failed to cd into project directory $PROJECT_DIR"
+    exit 1
+else
+    echo "Changed directory to $PROJECT_DIR"
+fi
+
+# Run migrations on leader or single-instance node
+if [[ "${EB_IS_COMMAND_LEADER:-}" == "true" ]] || [[ -z "${EB_IS_COMMAND_LEADER:-}" ]]; then
+    echo "Listing migrations before migrate:"
+    python manage.py showmigrations || echo "WARNING: Failed to list migrations (pre-migrate)"
+
+    echo "Running migrate command..."
+    if ! python manage.py migrate --noinput; then
+        echo "ERROR: Django migrate command failed!"
+        exit 1
     else
-        echo "Skipping migrations on non-leader node.";
+        echo "Django migrate completed successfully."
     fi
 
-}
+    echo "Listing migrations after migrate:"
+    python manage.py showmigrations || echo "WARNING: Failed to list migrations (post-migrate)"
+else
+    echo "Skipping migrations on non-leader node."
+fi
+
+echo "Django migrate script finished."

--- a/.platform/hooks/postdeploy/02_collectstatic.sh
+++ b/.platform/hooks/postdeploy/02_collectstatic.sh
@@ -1,14 +1,43 @@
 #!/bin/bash
+# Unified collectstatic script with dynamic virtualenv
+# Works for beta and prod environments
+# Prints detailed messages on failures
 
-source "$PYTHONPATH/activate" && {
+set -euo pipefail
 
-    if [[ $EB_IS_COMMAND_LEADER == "true" ]];
-    then
-        cd /var/app/current/src/odm2cvs || exit 1;
-        echo "Collecting static files:";
-        python manage.py collectstatic --noinput;
+echo "Starting collectstatic script..."
+
+# Resolve virtual environment dynamically
+VENV_DIR=$(ls -d /var/app/venv/* | head -n 1)
+VENV_ACTIVATE="$VENV_DIR/bin/activate"
+
+if ! source "$VENV_ACTIVATE"; then
+    echo "ERROR: Failed to activate virtual environment at $VENV_ACTIVATE"
+    exit 1
+else
+    echo "Virtual environment activated successfully."
+fi
+
+# Change directory to Django project
+PROJECT_DIR="/var/app/current/src/odm2cvs"
+if ! cd "$PROJECT_DIR"; then
+    echo "ERROR: Failed to cd into project directory $PROJECT_DIR"
+    exit 1
+else
+    echo "Changed directory to $PROJECT_DIR"
+fi
+
+# Run collectstatic on leader or single-instance node
+if [[ "${EB_IS_COMMAND_LEADER:-}" == "true" ]] || [[ -z "${EB_IS_COMMAND_LEADER:-}" ]]; then
+    echo "Collecting static files..."
+    if ! python manage.py collectstatic --noinput; then
+        echo "ERROR: collectstatic command failed!"
+        exit 1
     else
-        echo "Skipping static collection on non-leader node.";
+        echo "Static files collected successfully."
     fi
+else
+    echo "Skipping collectstatic on non-leader node."
+fi
 
-}
+echo "collectstatic script finished."

--- a/src/odm2cvs/cvservices/views.py
+++ b/src/odm2cvs/cvservices/views.py
@@ -1,3 +1,5 @@
-from django.shortcuts import render
+# view for health check
+from django.http.response import HttpResponse
 
-# Create your views here.
+def health_check(request):
+    return HttpResponse("OK")

--- a/src/odm2cvs/odm2cvs/urls.py
+++ b/src/odm2cvs/odm2cvs/urls.py
@@ -9,9 +9,13 @@ from cvinterface.views.base_views import UnitsListView
 from cvinterface.views.request_views import RequestsView, request_create_views, request_list_views, request_update_views
 from cvinterface.views.vocabulary_views import VocabulariesView, detail_views, list_views
 from cvservices.api import v1_api
+from cvservices.views import health_check
+
+
 
 urlpatterns = [
     re_path(r'^' + settings.SITE_URL + '$', VocabulariesView.as_view(), name='home'),
+    re_path(r'^' + settings.SITE_URL + 'health_check/', health_check, name='health_check'),
     re_path(r'^' + settings.SITE_URL + 'api/', include(v1_api.urls)),
     re_path(r'^' + settings.SITE_URL + 'admin/', admin.site.urls),
     re_path(r'^' + settings.SITE_URL + 'units/', UnitsListView.as_view(), name='units'),


### PR DESCRIPTION
These updated scripts no more using a constant venv path configured using the variable 'PYTHONPATH' which might the reason the scripts might be failing silently resulting in static files not getting collected when aws replaces an EC2 instance as part of the capacity rebalancing.  